### PR TITLE
macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ os:
   - linux
   - osx
 
-matrix:
-  allow_failures:
-    - os: osx
-
 script:
   - cd SQF-VM
   - make

--- a/SQF-VM/Entry.c
+++ b/SQF-VM/Entry.c
@@ -4,7 +4,7 @@
 #include "SQF_types.h"
 #include "SQF_parse.h"
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #ifdef __linux
 #include <alloca.h>
 #endif // _GCC
@@ -1143,7 +1143,7 @@ __attribute__((visibility("default"))) const char* start_program(const char* inp
 	return outputbuffer->val;
 }
 
-void main(int argc, char** argv)
+int main(int argc, char** argv)
 {
 	char linebuffer[LINEBUFFER_SIZE];
 	char* ptr = 0;

--- a/SQF-VM/SQF.c
+++ b/SQF-VM/SQF.c
@@ -5,7 +5,7 @@
 #include "SQF_types.h"
 #include "SQF_parse.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/SQF-VM/SQF_inst.c
+++ b/SQF-VM/SQF_inst.c
@@ -5,7 +5,7 @@
 #include "SQF_inst.h"
 #include "SQF_types.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 extern inline CPCMD get_command(PVM vm, PSTACK stack, PINST inst);

--- a/SQF-VM/SQF_parse.c
+++ b/SQF-VM/SQF_parse.c
@@ -4,7 +4,7 @@
 #include "SQF.h"
 #include "SQF_types.h"
 #include "SQF_parse.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/SQF-VM/SQF_types.c
+++ b/SQF-VM/SQF_types.c
@@ -2,7 +2,7 @@
 #include "SQF.h"
 #include "SQF_types.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 void TYPE_CODE_CALLBACK(void* input, CPCMD self);

--- a/SQF-VM/string_map.c
+++ b/SQF-VM/string_map.c
@@ -1,6 +1,6 @@
 #include "string_map.h"
 #include "string_op.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 extern inline void* sm_get_value(sm_list* list, const char* name);

--- a/SQF-VM/textrange.c
+++ b/SQF-VM/textrange.c
@@ -1,5 +1,5 @@
 #include "textrange.h"
-#include <malloc.h>
+#include <stdlib.h>
 
 TR_ARR* tr_arr_create(void)
 {


### PR DESCRIPTION
malloc exists in stdlib.h and is defined in the C89 and later standards
main function should return int value, at least in C99 and later