### PR TITLE
Correct main declaration should return int

### DIFF
--- a/SQF-VM/Entry.c
+++ b/SQF-VM/Entry.c
@@ -1143,7 +1143,7 @@ __attribute__((visibility("default"))) const char* start_program(const char* inp
 	return outputbuffer->val;
 }
 
-void main(int argc, char** argv)
+int main(int argc, char** argv)
 {
 	char linebuffer[LINEBUFFER_SIZE];
 	char* ptr = 0;


### PR DESCRIPTION
Without declaring an implicit return the value and exit code will be 0